### PR TITLE
[pnnl/SHAD#5] added wait calls after async operations in vector tests

### DIFF
--- a/test/unit_tests/data_structures/local_hashmap_test.cc
+++ b/test/unit_tests/data_structures/local_hashmap_test.cc
@@ -271,7 +271,6 @@ TEST_F(LocalHashmapTest, Erase) {
     }
   }
   ASSERT_EQ(hmap.Size(), currSize);
-  // hmap.Print(printfun);
   for (i = 0; i < kToInsert; i++) {
     Key k;
     FillKey(&k, i);

--- a/test/unit_tests/data_structures/vector_test.cc
+++ b/test/unit_tests/data_structures/vector_test.cc
@@ -125,6 +125,7 @@ TEST_F(VectorTest, BlockInsert) {
   for (size_t i = 0; i < 100; i++) {
     ASSERT_EQ(vectorPtr->At(i), i);
   }
+  shad::Vector<int>::Destroy(vectorPtr->GetGlobalID());
 }
 
 TEST_F(VectorTest, PushBack) {
@@ -150,6 +151,7 @@ TEST_F(VectorTest, PushBack) {
   }
   ASSERT_EQ(vectorPtr->Front(), 1);
   ASSERT_EQ(vectorPtr->Back(), 200);
+  shad::Vector<int>::Destroy(vectorPtr->GetGlobalID());
 }
 
 TEST_F(VectorTest, InsertAndAsyncAt) {
@@ -299,6 +301,7 @@ TEST_F(VectorTest, AsyncInsertSyncApplyAndAsyncGet) {
   for (size_t i = 0; i < kNumElements; i++) {
     ASSERT_EQ(values[i], i + 1 + (3 * kNumElements));
   }
+  shad::Vector<size_t>::Destroy(edsPtr->GetGlobalID());
 }
 
 static void asyncApplyFun(shad::rt::Handle & /*unused*/,
@@ -360,6 +363,7 @@ TEST_F(VectorTest, AsyncInsertAsyncApplyAndAsyncGet) {
   for (size_t i = 0; i < kNumElements; i++) {
     ASSERT_EQ(values[i], i + 1 + (3 * kNumElements));
   }
+  shad::Vector<size_t>::Destroy(edsPtr->GetGlobalID());
 }
 
 TEST_F(VectorTest, AsyncInsertSyncForEachInRangeAndAsyncGet) {
@@ -408,8 +412,10 @@ TEST_F(VectorTest, AsyncInsertAsyncForEachInRangeAndAsyncGet) {
   std::fill(std::begin(values), std::end(values), 0);
 
   edsPtr->AsyncForEachInRange(handle, 0, kNumElements, asyncApplyFunNoArgs);
+  shad::rt::waitForCompletion(handle);
   edsPtr->AsyncForEachInRange(handle, 0, kNumElements, asyncApplyFun,
                               kNumElements);
+  shad::rt::waitForCompletion(handle);
   size_t arg2 = kNumElements + 1;
   edsPtr->AsyncForEachInRange(handle, 0, kNumElements, asyncApplyFunTwoArgs,
                               kNumElements, arg2);


### PR DESCRIPTION
I did 1000 runs of each data-structures unit test, and they all passed (TBB build).
There is still a test (rarely) failing on the AsyncErase of the EdgeIndex.
We can address this in another issue.