### PR TITLE
[#147] Propose a specialized trait for random access iterators.

### DIFF
--- a/include/shad/core/array.h
+++ b/include/shad/core/array.h
@@ -915,11 +915,13 @@ class alignas(64) array<T, N>::array_iterator {
         begin.locality_ >= pivot_locality()) {
       start_block_size -= 1;
     }
+    if (begin.locality_ == end.locality_)
+      start_block_size = end.offset_;
     result.push_back(std::make_pair(begin.locality_,
-                                    start_block_size - begin.offset_ + 1));
+                                    start_block_size - begin.offset_));
 
     // Middle blocks:
-    for (auto locality = begin.locality_;
+    for (auto locality = begin.locality_ + 1;
          locality < end.locality_; ++locality) {
       typename array_iterator::difference_type inner_block_size = chunk_size();
       if (pivot_locality() != rt::Locality(0) &&
@@ -930,7 +932,8 @@ class alignas(64) array<T, N>::array_iterator {
     }
 
     // Last block:
-    result.push_back(std::make_pair(end.locality_, end.offset_));
+    if (begin.locality_ != end.locality_)
+      result.push_back(std::make_pair(end.locality_, end.offset_));
 
     return result;
   }

--- a/include/shad/core/array.h
+++ b/include/shad/core/array.h
@@ -932,7 +932,7 @@ class alignas(64) array<T, N>::array_iterator {
     }
 
     // Last block:
-    if (begin.locality_ != end.locality_)
+    if (end.offset_ != 0 && begin.locality_ != end.locality_)
       result.push_back(std::make_pair(end.locality_, end.offset_));
 
     return result;

--- a/include/shad/core/array.h
+++ b/include/shad/core/array.h
@@ -637,6 +637,8 @@ class alignas(64) array<T, N>::array_iterator {
 
   using local_iterator_type = pointer;
 
+  using distribution_range = std::vector<std::pair<rt::Locality, size_t>>;
+
   /// @brief Constructor.
   array_iterator(rt::Locality &&l, difference_type offset, ObjectID oid,
                  pointer chunk)
@@ -901,6 +903,36 @@ class alignas(64) array<T, N>::array_iterator {
       end = arrayPtr->chunk_.get() + E.offset_;
     }
     return local_iterator_range(begin, end);
+  }
+
+  static distribution_range
+      distribution(array_iterator &begin, array_iterator &end) {
+    distribution_range result;
+
+    // First block:
+    typename array_iterator::difference_type start_block_size = chunk_size();
+    if (pivot_locality() != rt::Locality(0) &&
+        begin.locality_ >= pivot_locality()) {
+      start_block_size -= 1;
+    }
+    result.push_back(std::make_pair(begin.locality_,
+                                    start_block_size - begin.offset_ + 1));
+
+    // Middle blocks:
+    for (auto locality = begin.locality_;
+         locality < end.locality_; ++locality) {
+      typename array_iterator::difference_type inner_block_size = chunk_size();
+      if (pivot_locality() != rt::Locality(0) &&
+          locality >= pivot_locality()) {
+        inner_block_size -= 1;
+      }
+      result.push_back(std::make_pair(locality, inner_block_size));
+    }
+
+    // Last block:
+    result.push_back(std::make_pair(end.locality_, end.offset_));
+
+    return result;
   }
 
   static rt::localities_range localities(array_iterator &B, array_iterator &E) {

--- a/include/shad/distributed_iterator_traits.h
+++ b/include/shad/distributed_iterator_traits.h
@@ -78,11 +78,12 @@ struct distributed_random_access_iterator_trait :
   using reference = typename distributed_iterator_traits<Iterator>::reference;
   using iterator_category =
       typename distributed_iterator_traits<Iterator>::iterator_category;
+  using distribution_range = typename Iterator::distribution_range;
 
-  using block_type = std::tuple<rt::Locality, Iterator, Iterator>;
-
-  static std::vector<block_type>
-  contiguos_block_list(Iterator begin, Iterator end);
+  static distribution_range
+  distribution(Iterator begin, Iterator end) {
+    return Iterator::distribution(begin, end);
+  }
 };
 
 }  // namespace shad

--- a/include/shad/distributed_iterator_traits.h
+++ b/include/shad/distributed_iterator_traits.h
@@ -70,6 +70,21 @@ struct is_distributed_iterator<T, typename std::enable_if<!std::is_same<
    static constexpr bool value = true;
 };
 
+template <typename Iterator>
+struct distributed_random_access_iterator_trait :
+      public distributed_iterator_traits<Iterator> {
+  using value_type = typename distributed_iterator_traits<Iterator>::value_type;
+  using pointer = typename distributed_iterator_traits<Iterator>::pointer;
+  using reference = typename distributed_iterator_traits<Iterator>::reference;
+  using iterator_category =
+      typename distributed_iterator_traits<Iterator>::iterator_category;
+
+  using block_type = std::tuple<rt::Locality, Iterator, Iterator>;
+
+  static std::vector<block_type>
+  contiguos_block_list(Iterator begin, Iterator end);
+};
+
 }  // namespace shad
 
 #endif /* INCLUDE_SHAD_DISTRIBUTED_ITERATOR_TRAIT_H */


### PR DESCRIPTION
The function contiguos_block_list returns a sequence of triples (l,b,e) where l
is the Locality, b is a global iterator to the start of a local block in l, and
e i the end of a local block in l.  The list contains one element for each and
every blocks that are in the input range.