### PR TITLE
fix issue with scope operators in array classes for GCC 11

### DIFF
--- a/include/shad/core/array.h
+++ b/include/shad/core/array.h
@@ -500,7 +500,7 @@ class array<T, N>::BaseArrayRef {
 template <typename T, std::size_t N>
 template <typename U>
 class alignas(64) array<T, N>::ArrayRef
-    : public array<T, N>::template BaseArrayRef<U> {
+    : public BaseArrayRef<U> {
  public:
   using value_type = U;
   using pointer = typename array<T, N>::pointer;
@@ -508,28 +508,28 @@ class alignas(64) array<T, N>::ArrayRef
   using ObjectID = typename array<T, N>::ObjectID;
 
   ArrayRef(rt::Locality l, difference_type p, ObjectID oid, pointer chunk)
-      : array<T, N>::template BaseArrayRef<U>(l, p, oid, chunk) {}
+      : BaseArrayRef<U>(l, p, oid, chunk) {}
 
-  ArrayRef(const ArrayRef &O) : array<T, N>::template BaseArrayRef<U>(O) {}
+  ArrayRef(const ArrayRef &O) : BaseArrayRef<U>(O) {}
 
-  ArrayRef(ArrayRef &&O) : array<T, N>::template BaseArrayRef<U>(O) {}
+  ArrayRef(ArrayRef &&O) : BaseArrayRef<U>(O) {}
 
   ArrayRef &operator=(const ArrayRef &O) {
-    array<T, N>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   ArrayRef &operator=(ArrayRef &&O) {
-    array<T, N>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   operator value_type() const {  // NOLINT
-    return array<T, N>::template BaseArrayRef<U>::get();
+    return BaseArrayRef<U>::get();
   }
 
   bool operator==(const ArrayRef &&v) const {
-    return array<T, N>::template BaseArrayRef<U>::operator==(v);
+    return BaseArrayRef<U>::operator==(v);
   }
 
   ArrayRef &operator=(const T &v) {
@@ -572,7 +572,7 @@ class alignas(64) array<T, N>::ArrayRef
 template <typename T, std::size_t N>
 template <typename U>
 class alignas(64) array<T, N>::ArrayRef<const U>
-    : public array<T, N>::template BaseArrayRef<U> {
+    : public BaseArrayRef<U> {
  public:
   using value_type = const U;
   using pointer = typename array<T, N>::pointer;
@@ -580,28 +580,28 @@ class alignas(64) array<T, N>::ArrayRef<const U>
   using ObjectID = typename array<T, N>::ObjectID;
 
   ArrayRef(rt::Locality l, difference_type p, ObjectID oid, pointer chunk)
-      : array<T, N>::template BaseArrayRef<U>(l, p, oid, chunk) {}
+      : BaseArrayRef<U>(l, p, oid, chunk) {}
 
-  ArrayRef(const ArrayRef &O) : array<T, N>::template BaseArrayRef<U>(O) {}
+  ArrayRef(const ArrayRef &O) : BaseArrayRef<U>(O) {}
 
-  ArrayRef(ArrayRef &&O) : array<T, N>::template BaseArrayRef<U>(O) {}
+  ArrayRef(ArrayRef &&O) : BaseArrayRef<U>(O) {}
 
   bool operator==(const ArrayRef &&v) const {
-    return array<T, N>::template BaseArrayRef<U>::operator==(v);
+    return BaseArrayRef<U>::operator==(v);
   }
 
   ArrayRef &operator=(const ArrayRef &O) {
-    array<T, N>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   ArrayRef &operator=(ArrayRef &&O) {
-    array<T, N>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   operator value_type() const {  // NOLINT
-    return array<T, N>::template BaseArrayRef<U>::get();
+    return BaseArrayRef<U>::get();
   }
 
   friend std::ostream &operator<<(std::ostream &stream, const ArrayRef i) {
@@ -629,7 +629,7 @@ template <typename T, std::size_t N>
 template <typename U>
 class alignas(64) array<T, N>::array_iterator {
  public:
-  using reference = typename array<T, N>::template ArrayRef<U>;
+  using reference = ArrayRef<U>;
   using pointer = typename array<T, N>::pointer;
   using difference_type = std::ptrdiff_t;
   using value_type = typename array<T, N>::value_type;

--- a/include/shad/data_structures/array.h
+++ b/include/shad/data_structures/array.h
@@ -1493,7 +1493,7 @@ class Array<T>::BaseArrayRef {
 template <typename T>
 template <typename U>
 class alignas(64) Array<T>::ArrayRef
-    : public Array<T>::template BaseArrayRef<U> {
+    : public BaseArrayRef<U> {
  public:
   using value_type = U;
   using pointer = typename Array<T>::pointer;
@@ -1501,28 +1501,28 @@ class alignas(64) Array<T>::ArrayRef
   using ObjectID = typename Array<T>::ObjectID;
 
   ArrayRef(rt::Locality l, difference_type p, ObjectID oid, pointer chunk)
-      : Array<T>::template BaseArrayRef<U>(l, p, oid, chunk) {}
+      : BaseArrayRef<U>(l, p, oid, chunk) {}
 
-  ArrayRef(const ArrayRef &O) : Array<T>::template BaseArrayRef<U>(O) {}
+  ArrayRef(const ArrayRef &O) : BaseArrayRef<U>(O) {}
 
-  ArrayRef(ArrayRef &&O) : Array<T>::template BaseArrayRef<U>(O) {}
+  ArrayRef(ArrayRef &&O) : BaseArrayRef<U>(O) {}
 
   ArrayRef &operator=(const ArrayRef &O) {
-    Array<T>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   ArrayRef &operator=(ArrayRef &&O) {
-    Array<T>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   operator value_type() const {  // NOLINT
-    return Array<T>::template BaseArrayRef<U>::get();
+    return BaseArrayRef<U>::get();
   }
 
   bool operator==(const ArrayRef &&v) const {
-    return Array<T>::template BaseArrayRef<U>::operator==(v);
+    return BaseArrayRef<U>::operator==(v);
   }
 
   ArrayRef &operator=(const T &v) {
@@ -1565,7 +1565,7 @@ class alignas(64) Array<T>::ArrayRef
 template <typename T>
 template <typename U>
 class alignas(64) Array<T>::ArrayRef<const U>
-    : public Array<T>::template BaseArrayRef<U> {
+    : public BaseArrayRef<U> {
  public:
   using value_type = const U;
   using pointer = typename Array<T>::pointer;
@@ -1573,28 +1573,28 @@ class alignas(64) Array<T>::ArrayRef<const U>
   using ObjectID = typename Array<T>::ObjectID;
 
   ArrayRef(rt::Locality l, difference_type p, ObjectID oid, pointer chunk)
-      : Array<T>::template BaseArrayRef<U>(l, p, oid, chunk) {}
+      : BaseArrayRef<U>(l, p, oid, chunk) {}
 
-  ArrayRef(const ArrayRef &O) : Array<T>::template BaseArrayRef<U>(O) {}
+  ArrayRef(const ArrayRef &O) : BaseArrayRef<U>(O) {}
 
-  ArrayRef(ArrayRef &&O) : Array<T>::template BaseArrayRef<U>(O) {}
+  ArrayRef(ArrayRef &&O) : BaseArrayRef<U>(O) {}
 
   bool operator==(const ArrayRef &&v) const {
-    return Array<T>::template BaseArrayRef<U>::operator==(v);
+    return BaseArrayRef<U>::operator==(v);
   }
 
   ArrayRef &operator=(const ArrayRef &O) {
-    Array<T>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   ArrayRef &operator=(ArrayRef &&O) {
-    Array<T>::template BaseArrayRef<U>::operator=(O);
+    BaseArrayRef<U>::operator=(O);
     return *this;
   }
 
   operator value_type() const {  // NOLINT
-    return Array<T>::template BaseArrayRef<U>::get();
+    return BaseArrayRef<U>::get();
   }
 
   friend std::ostream &operator<<(std::ostream &stream, const ArrayRef i) {
@@ -1607,7 +1607,7 @@ template <typename T>
 template <typename U>
 class alignas(64) Array<T>::array_iterator {
  public:
-  using reference = typename Array<T>::template ArrayRef<U>;
+  using reference = ArrayRef<U>;
   using pointer = typename Array<T>::pointer;
   using difference_type = std::ptrdiff_t;
   using value_type = typename Array<T>::value_type;


### PR DESCRIPTION
Compiling with GCC 11 produces multiple errors similar to the following:

```
SHAD/include/shad/data_structures/array.h:1496:49: error: expected class-name before '{' token
 1496 |     : public Array<T>::template BaseArrayRef<U> {
      |                                                 ^
```

Example build output: [shad_conan_build.txt](https://github.com/pnnl/SHAD/files/9146427/shad_conan_build.txt)

I believe the issue is the compiler doesn't need the `Array<T>::` scope operator where it's complaining because both the template class being defined (Array<T>::ArrayRef) and the the template class being referenced (Array<T>::BaseArrayRef) are both in the Array<T> class scope, so using the Array<T>:: scope operator for BaseArrayRef is redundant in the various contexts in which it appears.

This PR removes the `Array<T>::` and `array<T, N>::` scope operators in data_structures/array.h and core/array.h and the resulting code compiles.